### PR TITLE
Fix duty cycle to half period

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # check if sudo is required and save the result as ${PFX}:
 [[ ${EUID} -ne 0 ]] && PFX='sudo ' || PFX=''

--- a/examples/cli_song.sh
+++ b/examples/cli_song.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Example of how to export PWM Pin and play tones via CLI
+
+export WIRINGPI_DEBUG=true 
+export WIRINGPI_CODES=true 
+GPIO=../gpio/gpio
+
+$GPIO export 1 out
+$GPIO mode 1 pwm
+$GPIO pwmTone 1 1033
+
+for i in 262 523 220 440 233 466 0 0 262 523 220 440 233 466 0 0 175 349 147 294 156 311 0 0 175 349 147 294 156 311 0 0 311 277 294 277 311 311 208 196 277 262 370 349 165 466 440 415 311 247 233 220 208 0 0 0 ; do 
+	$GPIO pwmTone 1 $i;
+	sleep 0.15;
+done

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2319,7 +2319,7 @@ void pwmToneWrite (int pin, int freq)
     pwmWrite (pin, 0) ;             // Off
   else
   {
-    range = 600000 / freq ;
+    range = 200000 / freq ;
     pwmSetRange (range) ;
     pwmWrite    (pin, range / 2) ;
   }

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2321,7 +2321,7 @@ void pwmToneWrite (int pin, int freq)
   {
     range = 600000 / freq ;
     pwmSetRange (range) ;
-    pwmWrite    (pin, freq / 2) ;
+    pwmWrite    (pin, range / 2) ;
   }
 }
 


### PR DESCRIPTION
The original code allowed "active" period to be longer than the full period.

Actually we really only want active time to be half of period.

Also changed 600000 -> 200000 for the base "range/frequency" so that output matches tone test better. 
Reference: https://www.youtube.com/watch?v=xmKEhOS1QAo

Used direct piezo speaker on PWM1/GND
