### PR TITLE
Fixed #8; GPIO set pull down|up|disable modes (bananapro)

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -619,7 +619,7 @@ static uint8_t gpioToClkDiv [] =
 
 static int *physToPin ;
 
-static int upDnConvert[3] = {7, 7, 5};
+static int upDnConvert[3] = {0, 2, 1};
 
 static int pinToGpio_BP [64] =
 {
@@ -1924,8 +1924,6 @@ void pullUpDnControl (int pin, int pud)
 /*add for BananaPro by LeMaker team*/
 if(BPRVER == version)
 	{	
- 		pud = upDnConvert[pud];
-		
 		if ((pin & PI_GPIO_MASK) == 0)		// On-Board Pin
 		  {
 			   if (wiringPiMode == WPI_MODE_PINS)
@@ -1944,7 +1942,7 @@ if(BPRVER == version)
 					return;
 				}
 
-				pud &= 3 ;
+				pud = upDnConvert[pud]; // convert wiringpi pud to sunxi pud value
 				sunxi_pullUpDnControl(pin, pud);
 				return;
 		  }


### PR DESCRIPTION
I have tested this fix on the latest Raspbian distribution on the **BananaPro** platform.
Prior to this change the "pull" state for a GPIO pin reported as "_unknown_" for some of the attempted  pull states.

The following commands now works as expected:

```
bananapi@bpipro /sys/class/gpio/gpio4 $ cat pull
disable

bananapi@bpipro /sys/class/gpio/gpio4 $ gpio mode 7 up && cat pull
up

bananapi@bpipro /sys/class/gpio/gpio4 $ gpio mode 7 down && cat pull
down

bananapi@bpipro /sys/class/gpio/gpio4 $ gpio mode 7 off && cat pull
disable

bananapi@bpipro /sys/class/gpio/gpio4 $ gpio mode 7 up && cat pull
up

bananapi@bpipro /sys/class/gpio/gpio4 $ gpio mode 7 tri && cat pull
disable
```
